### PR TITLE
Multi orgs

### DIFF
--- a/resources/config.edn
+++ b/resources/config.edn
@@ -17,7 +17,7 @@
     :token              #env GITHUB_TOKEN
     :login              [#env GITHUB_USERNAME #env GITHUB_PASSWORD]
 
-    :org                #or [#env GITHUB_ORG "symphonyoss"]
+    :orgs               #or [#env GITHUB_ORGS ["hadouken" "fdc3" "finos" "finos-fo" "finos-osr" "finos-plexus" "finos-voice" "symphonyoss"]]
     :mask-private-repos #boolean #or [#env MASK_PRIVATE_REPOS true]   ; Should the tool mask private repos it has access to?
     :masked-repos       #split [#env MASKED_REPOS "\\s*,\\s*"]        ; Other named repos the tool should mask (may be private or public)
   }

--- a/resources/templates/add-comment.ftl
+++ b/resources/templates/add-comment.ftl
@@ -1,8 +1,8 @@
 [#ftl output_format="HTML" auto_esc=true strip_whitespace=true]
 <messageML>
 [#if success]
-<p>✅ Comment added to <a href="https://github.com/${org}/${repoName}/issues/${issueId}">${repoName} issue number ${issueId}</a>.</p>
-<p><b>View Issue Details Command:</b> id ${repoName} ${issueId}</p>
+<p>✅ Comment added to <a href="https://github.com/${repoSlug}/issues/${issueId}">${repoSlug} issue number ${issueId}</a>.</p>
+<p><b>View Issue Details Command:</b> id ${repoSlug} ${issueId}</p>
 [#else]
 <p class="tempo-text-color--red"><b>${errorMessage}</b></p>
 <p>Correct usage is <b>add-comment repo-name issue-number comment-text</b></p>

--- a/resources/templates/issue-detail.ftl
+++ b/resources/templates/issue-detail.ftl
@@ -15,7 +15,7 @@
   <header>
     <p>
       <div class="${titleBgStyle}"><hr/></div>
-      <b><a href="${issue.html_url}">${repoName} issue #${issue.number} - ${issue.title}</a></b><br/>
+      <b><a href="${issue.html_url}">${repoSlug} issue #${issue.number} - ${issue.title}</a></b><br/>
       <b>State: <span class="${textStyle}">${issue.state}</span></b> ❖
       <b>Type:</b> [#if issue.pull_request??]Pull request[#else]Issue[/#if] ❖
       <b>Created by:</b> <a href="${issue.user.html_url}">${issue.user.login}</a> on ${issue.created_at?datetime.iso?string["yyyy-MM-dd h:mm:ssa z"]} ❖
@@ -25,7 +25,7 @@
 [#if issue.body??]
     <p><b>Description:</b> ${issue.body}</p>
 [/#if]
-    <p><b>Add Comment Command:</b> ac ${repoName} ${issue.number} [COMMENT TEXT HERE]</p>
+    <p><b>Add Comment Command:</b> ac ${repoSlug} ${issue.number} [COMMENT TEXT HERE]</p>
 [#if issue.comments > 0 && issue.comment_data??]
     <p><i>Click to see ${issue.comments} comments</i></p>
 [/#if]

--- a/resources/templates/issues-summary-table.ftl
+++ b/resources/templates/issues-summary-table.ftl
@@ -10,7 +10,7 @@
     <thead><tr><th>Number</th><th>Type</th><th>State</th><th>Title</th><th>Raised By</th><th>Assigned To</th><th>Created</th><th>Updated</th><th>View Issue Details Command</th></tr></thead>
     <tbody>
     [#list issues as issue]
-      <tr><td><b><a href="${issue.html_url}">${issue.number}</a></b></td><td>[#if issue.pull_request??]Pull request[#else]Issue[/#if]</td><td><b class="[@issueStateToTextStyle issueState=issue.state/]">${issue.state}</b></td><td>${issue.title}</td><td><a href="${issue.user.html_url}">${issue.user.login}</a></td><td>[#if issue.assignee??]<a href="${issue.assignee.html_url}">${issue.assignee.login}</a>[/#if]</td><td>${issue.created_at?datetime.iso?string["yyyy-MM-dd h:mm:ssa z"]}</td><td>${issue.updated_at?datetime.iso?string["yyyy-MM-dd h:mm:ssa z"]}</td><td>id ${repoName} ${issue.number}</td></tr>
+      <tr><td><b><a href="${issue.html_url}">${issue.number}</a></b></td><td>[#if issue.pull_request??]Pull request[#else]Issue[/#if]</td><td><b class="[@issueStateToTextStyle issueState=issue.state/]">${issue.state}</b></td><td>${issue.title}</td><td><a href="${issue.user.html_url}">${issue.user.login}</a></td><td>[#if issue.assignee??]<a href="${issue.assignee.html_url}">${issue.assignee.login}</a>[/#if]</td><td>${issue.created_at?datetime.iso?string["yyyy-MM-dd h:mm:ssa z"]}</td><td>${issue.updated_at?datetime.iso?string["yyyy-MM-dd h:mm:ssa z"]}</td><td>id ${repoSlug} ${issue.number}</td></tr>
     [/#list]
     </tbody>
   </table>

--- a/resources/templates/list-issues.ftl
+++ b/resources/templates/list-issues.ftl
@@ -1,7 +1,7 @@
 [#ftl output_format="HTML" auto_esc=true strip_whitespace=true]
 <messageML>
 [#if success]
-<b>${summary?capitalize} issues in ${repoName}:</b>
+<b>${summary?capitalize} issues in ${repoSlug}:</b>
 <p>
   [#if issues?? && issues?size > 0]
     [#include "issues-summary-table.ftl"]

--- a/resources/templates/list-repos.ftl
+++ b/resources/templates/list-repos.ftl
@@ -6,7 +6,7 @@
   <table>
     <tr><th>Name</th><th>Description</th><th>List Open Issues Command</th></tr>
   [#list repos?sort_by("name") as repo]
-    <tr><td><a href="${repo.html_url}">${repo.name}</a></td><td>${repo.description!""}</td><td>loi ${repo.name}</td></tr>
+    <tr><td><a href="${repo.html_url}">${repo.full_name}</a></td><td>${repo.description!""}</td><td>loi ${repo.full_name}</td></tr>
   [/#list]
   </table>
 [#else]

--- a/src/bot_github_chatops/commands.clj
+++ b/src/bot_github_chatops/commands.clj
@@ -119,7 +119,7 @@
                                             (try
                                               [true nil (doall (map (partial gh/issue repo-slug) issue-ids))]
                                               (catch Exception e
-                                                [false (str e " - Invalid repository (" repo-slug "), and/or issue numbers (" (s/join ", " raw-issue-ids) ").") nil]))
+                                                [false (str "Invalid repository (" repo-slug "), and/or issue numbers (" (s/join ", " raw-issue-ids) ").") nil]))
                                             [success error-message nil])
         message                           (tem/render "issue-details.ftl"
                                                       { :success      success
@@ -128,10 +128,10 @@
                                                         :issues       issues
                                                         :errorMessage error-message })]
     (sym/send-message! cnxn/symphony-connection
-                      stream-id
-                      message)))
+                       stream-id
+                       message)))
 
-                    
+
 (defn- add-comment!
   "Adds a comment to an issue in a given repository. The repository name must be supplied immediately after the command, followed by a single issue id, followed by the comment e.g. add-comment MyRepository 42 Can you please provide the log files?"
   [from-user-id stream-id _ words]

--- a/src/bot_github_chatops/commands.clj
+++ b/src/bot_github_chatops/commands.clj
@@ -49,19 +49,19 @@
   "Lists issues for the given repository in the given state."
   [stream-id words summary command-name issue-filter]
   (let [arguments                      (rest words)
-        repo-name                      (first arguments)
-        [success error-message]        (if-not (s/blank? repo-name)
+        repo-slug                      (first arguments)
+        [success error-message]        (if-not (s/blank? repo-slug)
                                          [true  nil]
                                          [false "No repository was provided, but it is required."])
         [success error-message issues] (if success
                                          (try
-                                           [true nil (gh/issues repo-name issue-filter)]
+                                           [true nil (gh/issues repo-slug issue-filter)]
                                            (catch Exception e
-                                             [false (str "Invalid repository '" repo-name "'.") nil]))
+                                             [false (str "Invalid repository '" repo-slug "'.") nil]))
                                          [success error-message nil])
         message                        (tem/render "list-issues.ftl"
                                                    { :success      success
-                                                     :repoName     repo-name
+                                                     :repoSlug     repo-slug
                                                      :summary      summary
                                                      :commandName  command-name
                                                      :issues       issues
@@ -99,8 +99,8 @@
   "Displays details on one or more issues in a given repository. The repository name must be supplied immediately after the command, followed by one or more issue ids e.g. issue-details MyRepository 14 17 22"
   [_ stream-id _ words]
   (let [arguments                         (rest words)
-        repo-name                         (first arguments)
-        [success error-message]           (if-not (s/blank? repo-name)
+        repo-slug                         (first arguments)
+        [success error-message]           (if-not (s/blank? repo-slug)
                                             [true  nil]
                                             [false "No repository was provided, but it is required."])
         raw-issue-ids                     (rest arguments)
@@ -117,27 +117,27 @@
                                             [success error-message nil])
         [success error-message issues]    (if success
                                             (try
-                                              [true nil (doall (map (partial gh/issue repo-name) issue-ids))]
+                                              [true nil (doall (map (partial gh/issue repo-slug) issue-ids))]
                                               (catch Exception e
-                                                [false (str "Invalid repository (" repo-name "), and/or issue numbers (" (s/join ", " raw-issue-ids) ").") nil]))
+                                                [false (str e " - Invalid repository (" repo-slug "), and/or issue numbers (" (s/join ", " raw-issue-ids) ").") nil]))
                                             [success error-message nil])
         message                           (tem/render "issue-details.ftl"
                                                       { :success      success
-                                                        :repoName     repo-name
+                                                        :repoSlug     repo-slug
                                                         :issueIds     issue-ids
                                                         :issues       issues
                                                         :errorMessage error-message })]
     (sym/send-message! cnxn/symphony-connection
-                       stream-id
-                       message)))
+                      stream-id
+                      message)))
 
-
+                    
 (defn- add-comment!
   "Adds a comment to an issue in a given repository. The repository name must be supplied immediately after the command, followed by a single issue id, followed by the comment e.g. add-comment MyRepository 42 Can you please provide the log files?"
   [from-user-id stream-id _ words]
   (let [arguments                         (rest words)
-        repo-name                         (first arguments)
-        [success error-message]           (if-not (s/blank? repo-name)
+        repo-slug                         (first arguments)
+        [success error-message]           (if-not (s/blank? repo-slug)
                                             [true  nil]
                                             [false "No repository was provided, but it is required."])
         raw-issue-id                      (first (rest arguments))
@@ -158,18 +158,17 @@
                                                                                  { :displayName  (:display-name from-user)
                                                                                    :userId       from-user-id
                                                                                    :message      comment-text })]
-                                                  (gh/add-comment repo-name
+                                                  (gh/add-comment repo-slug
                                                                   issue-id
                                                                   github-comment)
                                                   [true nil])
                                                 (catch Exception e
-                                                  [false (str "Invalid repository (" repo-name "), and/or issue number (" raw-issue-id ").")]))
+                                                  [false (str "Invalid repository (" repo-slug "), and/or issue number (" raw-issue-id ").")]))
                                               [false "No comment was provided, but it is required."])
                                             [success error-message])
         message                           (tem/render "add-comment.ftl"
                                                       { :success      success
-                                                        :org          gh/org
-                                                        :repoName     repo-name
+                                                        :repoSlug     repo-slug
                                                         :issueId      issue-id
                                                         :errorMessage error-message })]
     (sym/send-message! cnxn/symphony-connection

--- a/src/bot_github_chatops/github.clj
+++ b/src/bot_github_chatops/github.clj
@@ -30,11 +30,8 @@
                    result
                    (throw (RuntimeException. "GitHub configuration is mandatory, but is missing."))))
 
-(defstate org
-          :start (let [result (:org github-config)]
-                   (if-not (s/blank? result)
-                     result
-                     "symphonyoss")))
+(defstate orgs
+          :start (:orgs github-config))
 
 (defstate opts
           :start (into { :throw-exceptions true
@@ -58,16 +55,29 @@
           :start (if-let [from-config (seq (:masked-repos github-config))]
                    (set from-config)))
 
+(defn get-repo-org
+  "Returns the org of a repo (ie 'symphonyoss', given its slug, ie 'symphonyoss/contrib-toolbox'"
+  [repo-slug]
+  (first (s/split repo-slug #"/")))
+
+(defn- get-repo-name
+  "Returns the name of a repo (ie 'contrib-toolbox', given its slug, ie 'symphonyoss/contrib-toolbox'"
+  [repo-slug]
+  (second (s/split repo-slug #"/")))
+  
 (defn private-repo?
   "Is the given repository private?"
-  [repo-name]
-  (:private (tr/specific-repo org repo-name opts)))
+  [repo-slug]
+  (let [org       (get-repo-org repo-slug)
+        repo-name (get-repo-name repo-slug)]
+    (:private (tr/specific-repo org repo-name opts))))
 
 (defn- masked-repo-fn?
   "Is the given repository masked?"
-  [repo-name]
-  (or (contains? masked-repos repo-name)
-      (and mask-private-repos? (private-repo? repo-name))))
+  [repo-slug]
+    (or (contains? masked-repos repo-slug)
+        (and mask-private-repos? (private-repo? repo-slug))))
+
 (def ^:private masked-repo? (memo/lru masked-repo-fn? :lru/threshold 500))   ; Memoize so as to reduce GH API calls
 
 ; We do this so that configuration reloads via the bot's admin command interface force a flush of the masked-repo? cache.
@@ -77,8 +87,8 @@
 (defn repos
   "Lists the non-masked repositories in the configured org."
   []
-  (let [result (tr/org-repos org opts)]
-    (doall (remove #(masked-repo? (:name %)) result))))
+  (let [result (flatten (map #(tr/org-repos % opts) orgs))]
+    (doall (remove #(masked-repo? (:full_name %)) result))))
 
 (defn issues
   "Lists issues in the given repo, optionally including these filtering and sorting options:
@@ -92,25 +102,29 @@
     sort-field     - 'created', 'updated', or 'comments'
     sort-direction - 'asc' or 'desc'
     since          - issues updated since this date (formatted as an ISO 8601 string: 'YYYY-MM-DDTHH:MM:SSZ')"
-  ([repo-name] (issues repo-name nil))
-  ([repo-name filters]
-   (if-not (masked-repo? repo-name)
-     (ti/issues org repo-name (into opts filters))
-     (throw (RuntimeException. (str "Invalid repository '" repo-name "'."))))))
+  ([repo-slug] (issues repo-slug nil))
+  ([repo-slug filters]
+  (let [org       (get-repo-org repo-slug)
+        repo-name (get-repo-name repo-slug)]
+    (if-not (masked-repo? repo-slug)
+      (ti/issues org repo-name (into opts filters))
+      (throw (RuntimeException. (str "Invalid repository '" repo-slug "'.")))))))
 
 (defn issue
   "Gets the details of a single issue in the given repo, including comments."
-  [repo-name issue-id]
-  (if-not (masked-repo? repo-name)
-    (assoc (ti/specific-issue org repo-name issue-id opts)
-           :comment_data (ti/issue-comments org repo-name issue-id opts))
-    (throw (RuntimeException. (str "Invalid repository " repo-name)))))
-
+  [repo-slug issue-id]
+  (let [org       (get-repo-org repo-slug)
+        repo-name (get-repo-name repo-slug)]
+    (if-not (masked-repo? repo-slug)
+      (assoc (ti/specific-issue org repo-name issue-id opts)
+             :comment_data (ti/issue-comments org repo-name issue-id opts))
+      (throw (RuntimeException. (str "Invalid repository " repo-slug))))))
 
 (defn add-comment
   "Adds the given content as a comment to the given issue."
-  [repo-name issue-id comment-content]
-  (if-not (masked-repo? repo-name)
-    (ti/create-comment org repo-name issue-id comment-content opts)
-    (throw (RuntimeException. (str "Invalid repository " repo-name)))))
-
+  [repo-slug issue-id comment-content]
+  (let [org       (get-repo-org repo-slug)
+        repo-name (get-repo-name repo-slug)]
+    (if-not (masked-repo? repo-slug)
+      (ti/create-comment org repo-name issue-id comment-content opts)
+      (throw (RuntimeException. (str "Invalid repository " repo-slug))))))


### PR DESCRIPTION
I've implemented multi-org by simply adding a list of orgs in `config.edn` and changed code accordingly; I've deployed the bot on foundation-dev and tested all commands successfully.

For most cases, the change was as simple as replacing `repo-name` with `repo-slug` and `repo.name` to `repo.full_name`.

Regarding the repo list, I've applied a map&flatten approach:
```
(let [result (flatten (map #(tr/org-repos % opts) orgs))]
```

Given that there are members urgently waiting for this fix, I'd propose to review and merge it to master (so it gets deployed to our Symphony pod); however, I'd like to add the following features:
- list-repos must return entries ordered alphabetically (which would also enforce results ordered by org
- list-repos must accept an optional `org` parameter, to only return repos of a given org
